### PR TITLE
42 complete additional metrics for trend following

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["macd"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["macd"]
+  "cSpell.words": ["lookback", "macd", "perc"]
 }

--- a/data-points.json
+++ b/data-points.json
@@ -90,26 +90,6 @@
       "fullName": "Bollinger Band Breakout"
     }
   },
-  "timeFilters": {
-    "sessionStart": {
-      "value": "09:30",
-      "description": "Start of trading session",
-      "fullName": "Session Start Time"
-    },
-    "sessionEnd": {
-      "value": "16:00",
-      "description": "End of trading session",
-      "fullName": "Session End Time"
-    },
-    "excludedTimeRanges": [
-      {
-        "start": "09:30",
-        "end": "10:00",
-        "description": "Avoid trading during this range",
-        "fullName": "Excluded Time Window"
-      }
-    ]
-  },
   "optionalConfirmations": {
     "RSI": {
       "period": 14,
@@ -141,12 +121,43 @@
       "fullName": "Bullish Exhaustion Gap"
     }
   },
-  "entryCooldown": {
-    "minBarsBetweenTrades": 10,
-    "description": "Minimum bars between entries to avoid overtrading",
-    "fullName": "Cooldown Period"
+  "limiter-filters": {
+    "entryCooldown": {
+      "minBarsBetweenTrades": 10,
+      "description": "Minimum bars between entries to avoid overtrading",
+      "fullName": "Cooldown Period"
+    },
+    "sessionStart": {
+      "value": "09:30",
+      "description": "Start of trading session",
+      "fullName": "Session Start Time"
+    },
+    "sessionEnd": {
+      "value": "16:00",
+      "description": "End of trading session",
+      "fullName": "Session End Time"
+    },
+    "excludedTimeRanges": [
+      {
+        "start": "09:30",
+        "end": "10:00",
+        "description": "Avoid trading during this range",
+        "fullName": "Opening exclusion"
+      },
+      {
+        "start": "03:45",
+        "end": "04:00",
+        "description": "Avoid trading during this range",
+        "fullName": "Closing exclusion"
+      }
+    ],
+    "maxOpenPositions": {
+      "value": 1,
+      "description": "Restrict to one open trade at a time",
+      "fullName": "Single Position Mode"
+    }
   },
-  "riskControls": {
+  "positionMonitor-riskControls": {
     "stopLossATR": {
       "multiplier": 1.5,
       "description": "Stop loss distance as multiple of ATR",
@@ -157,10 +168,9 @@
       "description": "Take profit at 2:1 risk-reward ratio",
       "fullName": "Risk-Reward Target"
     },
-    "maxOpenPositions": {
-      "value": 1,
-      "description": "Restrict to one open trade at a time",
-      "fullName": "Single Position Mode"
+    "finalHoldTime": {
+      "time": "03:53",
+      "description": "The latest time a position can be held to"
     }
   }
 }

--- a/src/algorithms/_output.ts
+++ b/src/algorithms/_output.ts
@@ -6,7 +6,7 @@ import { DailyDataGroups, buildDailyDistributions } from './distributions-ranges
 import { groupByDays } from './general-utilities'
 import { getAllNoiseWindows } from './noise-windows'
 import { detectMAConfirmedCrossing } from './signal-algos/trend-following'
-import { calculateADX, calculateEMA1, calculateEMA2, calculateSMA1 } from './trend-analysis'
+import { calculateADX, calculateEMA1, calculateEMA2, calculateMACD, calculateSMA1 } from './trend-analysis'
 import { calculateRSI, generateBollingerSeries } from './volatility-analysis'
 
 export function algoOutput(requestParams: Partial<RequestParams>, passedData?: TransactionPacket) {
@@ -36,6 +36,7 @@ export function algoOutput(requestParams: Partial<RequestParams>, passedData?: T
   let noiseWindows = undefined
   let bollingerBands = undefined
   let RSI = undefined
+  let MACD = undefined
 
   /* Single Direction Blocks */
   singleDirectionBlocks = detectSingleDirection(data, requestParams)
@@ -64,6 +65,9 @@ export function algoOutput(requestParams: Partial<RequestParams>, passedData?: T
 
   /* Bollinger Bands */
   bollingerBands = generateBollingerSeries(data, 20, 2)
+
+  /* MACD */
+  MACD = calculateMACD(data, requestParams)
 
   /* Create ExtendedTick Data */
   let extendedTickData
@@ -104,6 +108,7 @@ export function algoOutput(requestParams: Partial<RequestParams>, passedData?: T
       EMA2: EMA2,
       ADX: ADX,
       RSI: RSI,
+      MACD: MACD,
       crossingSignal: crossingSignal,
       noiseWindows: noiseWindows,
       bollingerBands,

--- a/src/algorithms/_output.ts
+++ b/src/algorithms/_output.ts
@@ -7,7 +7,7 @@ import { groupByDays } from './general-utilities'
 import { getAllNoiseWindows } from './noise-windows'
 import { detectMAConfirmedCrossing } from './signal-algos/trend-following'
 import { calculateADX, calculateEMA1, calculateEMA2, calculateSMA1 } from './trend-analysis'
-import { generateBollingerSeries } from './volatility-analysis'
+import { calculateRSI, generateBollingerSeries } from './volatility-analysis'
 
 export function algoOutput(requestParams: Partial<RequestParams>, passedData?: TransactionPacket) {
   /* Early returns */
@@ -35,6 +35,7 @@ export function algoOutput(requestParams: Partial<RequestParams>, passedData?: T
   let crossingSignal = undefined
   let noiseWindows = undefined
   let bollingerBands = undefined
+  let RSI = undefined
 
   /* Single Direction Blocks */
   singleDirectionBlocks = detectSingleDirection(data, requestParams)
@@ -57,6 +58,9 @@ export function algoOutput(requestParams: Partial<RequestParams>, passedData?: T
 
   /* Average Directional Index */
   ADX = calculateADX(data, requestParams)
+
+  /* RSI (Relative Strength Index) */
+  RSI = calculateRSI(data, requestParams)
 
   /* Bollinger Bands */
   bollingerBands = generateBollingerSeries(data, 20, 2)
@@ -99,6 +103,7 @@ export function algoOutput(requestParams: Partial<RequestParams>, passedData?: T
       EMA1: EMA1,
       EMA2: EMA2,
       ADX: ADX,
+      RSI: RSI,
       crossingSignal: crossingSignal,
       noiseWindows: noiseWindows,
       bollingerBands,

--- a/src/algorithms/_output.ts
+++ b/src/algorithms/_output.ts
@@ -64,7 +64,15 @@ export function algoOutput(requestParams: Partial<RequestParams>, passedData?: T
   /* Create ExtendedTick Data */
   let extendedTickData
   if (SMA1 && EMA1 && EMA2) {
-    extendedTickData = extendTickData(data, SMA1.data, EMA1.data, EMA2.data, dailyDistributions, requestParams)
+    extendedTickData = extendTickData(
+      data,
+      SMA1.data,
+      EMA1.data,
+      EMA2.data,
+      bollingerBands,
+      dailyDistributions,
+      requestParams,
+    )
   }
 
   /* CrossingSignal (BuySignal) */

--- a/src/algorithms/data-extension.ts
+++ b/src/algorithms/data-extension.ts
@@ -6,7 +6,15 @@ import {
 } from './distributions-ranges'
 import { isCandleWickCrossingAvg, isCandleBodyCrossingAvg, findBodyCrossingPercent } from './entry-triggers'
 import { isGreenCandle, isCandleFullByPercentage, getCandleBodyFullness } from './general-utilities'
-import { bollingerBreakout, getPercentSlopeByPeriod, getPriceSlopeByPeriod, MACrossover } from './trend-analysis'
+import {
+  bollingerBreakout,
+  getBearishEngulfingScore,
+  getPercentSlopeByPeriod,
+  getPriceSlopeByPeriod,
+  isBullishExhaustion,
+  MACrossover,
+} from './trend-analysis'
+import { calculateVolumeTrend, calculateVolumeTrendScore } from './volume-utils'
 
 export const extendTickData = (
   data: TickArray,
@@ -37,6 +45,8 @@ export const extendTickData = (
       longEmaAvg: emaAvgArrayLong[index],
       emaCrossing: MACrossover(emaAvgArrayShort, emaAvgArrayLong, index),
       bollingerBreakout: bollingerBreakout(tick, bollingerSeries, index),
+      bearishEngulfingScore: getBearishEngulfingScore(data, index, requestParams),
+      isBullishExhaustion: isBullishExhaustion(data, index, requestParams),
       isWickCrossing: isCandleWickCrossingAvg(tick, maAvgArrayShort[index]),
       isBodyCrossing: false,
       crossesBodyAtPercent: null,
@@ -52,7 +62,8 @@ export const extendTickData = (
         previousDayDistributions.volume.volLow,
         previousDayDistributions.volume.distributionBlock,
       ),
-      value: [tick.timestamp, null],
+      volumeTrendIncreasing: calculateVolumeTrendScore(data, index, requestParams),
+      value: [tick.timestamp, null], // WHAT IS THIS? I think it's for a hidden display point? Verify or Retire.
       percSlopeByPeriod:
         index >= +requestParams.algoParams?.slopePeriodRawPrice
           ? getPercentSlopeByPeriod(data, index, requestParams, 'close')

--- a/src/algorithms/data-extension.ts
+++ b/src/algorithms/data-extension.ts
@@ -6,13 +6,14 @@ import {
 } from './distributions-ranges'
 import { isCandleWickCrossingAvg, isCandleBodyCrossingAvg, findBodyCrossingPercent } from './entry-triggers'
 import { isGreenCandle, isCandleFullByPercentage, getCandleBodyFullness } from './general-utilities'
-import { calculateSMA, getPercentSlopeByPeriod, getPriceSlopeByPeriod } from './trend-analysis'
+import { bollingerBreakout, getPercentSlopeByPeriod, getPriceSlopeByPeriod, MACrossover } from './trend-analysis'
 
 export const extendTickData = (
   data: TickArray,
   maAvgArrayShort: number[],
   emaAvgArrayShort: number[],
   emaAvgArrayLong: number[],
+  bollingerSeries: any,
   dailyDistributions: any,
   requestParams: Partial<RequestParams>,
 ): ExtTick[] => {
@@ -34,7 +35,8 @@ export const extendTickData = (
       movingAvg: maAvgArrayShort[index],
       shortEmaAvg: emaAvgArrayShort[index],
       longEmaAvg: emaAvgArrayLong[index],
-      isMACrossingEMA: false,
+      emaCrossing: MACrossover(emaAvgArrayShort, emaAvgArrayLong, index),
+      bollingerBreakout: bollingerBreakout(tick, bollingerSeries, index),
       isWickCrossing: isCandleWickCrossingAvg(tick, maAvgArrayShort[index]),
       isBodyCrossing: false,
       crossesBodyAtPercent: null,

--- a/src/algorithms/trend-analysis.ts
+++ b/src/algorithms/trend-analysis.ts
@@ -204,7 +204,6 @@ export function calculateADX(ticks: TickArray, requestParams: Partial<RequestPar
     plusDM.push(upMove > downMove && upMove > 0 ? upMove : 0)
     minusDM.push(downMove > upMove && downMove > 0 ? downMove : 0)
 
-    // eslint-disable-next-line prettier/prettier
     tr.push(Math.max(curr.high - curr.low, Math.abs(curr.high - prev.close), Math.abs(curr.low - prev.close)))
   }
 
@@ -260,11 +259,12 @@ export function calculateADX(ticks: TickArray, requestParams: Partial<RequestPar
   return adxResults
 }
 
-const MACrossover = (
-  fastMaArray: (number | null)[], // Shorter period Moving Average
-  slowMaArray: (number | null)[], // Longer period Moving Average
+export const MACrossover = (
+  fastMaArray: (number | null)[] | undefined, // Shorter period Moving Average
+  slowMaArray: (number | null)[] | undefined, // Longer period Moving Average
   index: number,
-): [boolean, 'bullish' | 'bearish' | undefined] | undefined => {
+): { crossing: boolean; direction: 'bullish' | 'bearish' | undefined } => {
+  if (fastMaArray === undefined || slowMaArray === undefined) return { crossing: false, direction: undefined }
   let direction: 'bullish' | 'bearish' | undefined
   let crossing: boolean
   let prevFastMa = fastMaArray[index - 1]
@@ -272,7 +272,8 @@ const MACrossover = (
   let currFastMa = fastMaArray[index]
   let currSlowMa = slowMaArray[index]
 
-  if (prevFastMa === null || prevSlowMa === null || currFastMa === null || currSlowMa === null) return
+  if (prevFastMa === null || prevSlowMa === null || currFastMa === null || currSlowMa === null)
+    return { crossing: false, direction: undefined }
 
   if (prevFastMa < prevSlowMa && currFastMa > currSlowMa) {
     direction = 'bullish'
@@ -284,5 +285,10 @@ const MACrossover = (
     direction = undefined
     crossing = false
   }
-  return [crossing, direction]
+  return { crossing, direction }
+}
+
+export const bollingerBreakout = (tick: Tick, bollingerSeries: any, index: number) => {
+  if (bollingerSeries[0].data[index] === null) return false
+  return tick.close > bollingerSeries[0].data[index] ? true : false
 }

--- a/src/algorithms/volume-utils.ts
+++ b/src/algorithms/volume-utils.ts
@@ -1,5 +1,6 @@
 /* Volume Utils */
 
+import { RequestParams, TickArray } from '../types/types'
 import { findTickVolumeDistribution } from './distributions-ranges'
 import { isGreenCandle } from './general-utilities'
 
@@ -30,4 +31,142 @@ export const directionalBlockVolumeAnalysis = (directionalArray: any[], volumeDi
   })
 
   return result
+}
+
+// export const calculateVolumeStepTrend = (
+//   data: TickArray,
+//   index: number,
+//   requestParams: Partial<RequestParams>,
+// ): boolean | null => {
+//   if (!requestParams.algoParams) return null
+//   const lookback = +requestParams.algoParams.volumeTrendLookback
+//   const minGrowthSteps = +requestParams.algoParams.volumeTrendMinGrowthSteps
+
+//   if (index < lookback) return null
+
+//   let upCount = 0
+
+//   for (let j = index - lookback + 1; j <= index; j++) {
+//     if (data[j].volume > data[j - 1].volume) {
+//       upCount++
+//     }
+//   }
+
+//   return upCount >= minGrowthSteps
+// }
+
+// export const calculateVolumeTrendScore = (
+//   data: TickArray,
+//   index: number,
+//   requestParams: Partial<RequestParams>,
+// ): number | null => {
+//   if (!requestParams.algoParams) return null
+//   const lookback = +requestParams.algoParams.volumeTrendLookback
+//   const maxDropPercentage = +requestParams.algoParams.volumeTrendMaxDrop
+//   if (index < lookback) return null
+
+//   let upSteps = 0
+//   let maxDrop = 0
+
+//   for (let j = index - lookback + 1; j <= index; j++) {
+//     const prev = data[j - 1].volume
+//     const curr = data[j].volume
+
+//     if (curr > prev) {
+//       upSteps++
+//     } else {
+//       const drop = (prev - curr) / prev
+//       if (drop > maxDrop) maxDrop = drop
+//     }
+//   }
+
+//   const upScore = upSteps / lookback
+//   const dropPenalty = Math.min(maxDrop / maxDropPercentage, 1) // cap at 1
+
+//   const score = upScore * (1 - dropPenalty)
+//   return score
+// }
+
+// export const calculateVolumeTrendScore = (
+//   data: TickArray,
+//   index: number,
+//   requestParams: Partial<RequestParams>,
+// ): number | null => {
+//   if (!requestParams.algoParams) return null
+//   const lookback = +requestParams.algoParams.volumeTrendLookback
+//   const maxAllowedMedianDrop = +requestParams.algoParams.volumeTrendMaxDrop
+//   if (index < lookback) return null
+
+//   const slice = data.slice(index - lookback + 1, index + 1)
+//   const volumes = slice.map((d) => d.volume).sort((a, b) => a - b)
+
+//   const medianVolume =
+//     volumes.length % 2 === 0
+//       ? (volumes[volumes.length / 2 - 1] + volumes[volumes.length / 2]) / 2
+//       : volumes[Math.floor(volumes.length / 2)]
+
+//   let upSteps = 0
+//   let maxDrop = 0
+
+//   for (let j = index - lookback + 1; j <= index; j++) {
+//     const prev = data[j - 1].volume
+//     const curr = data[j].volume
+
+//     if (curr > prev) upSteps++
+
+//     const dropFromMedian = (medianVolume - curr) / medianVolume
+//     if (dropFromMedian > maxDrop) {
+//       maxDrop = dropFromMedian
+//     }
+//   }
+
+//   const upScore = upSteps / lookback
+//   const penalty = Math.min(maxDrop / maxAllowedMedianDrop, 1)
+
+//   return upScore * (1 - penalty)
+// }
+
+export const calculateVolumeTrendScore = (
+  data: TickArray,
+  index: number,
+  requestParams: Partial<RequestParams>,
+): number | null => {
+  if (!requestParams.algoParams) return null
+
+  const lookback = +requestParams.algoParams.volumeTrendLookback
+  const minUpTrendScore = +requestParams.algoParams.volumeTrendMinTrend || 0.65
+  const minSurgeMultiplier = +requestParams.algoParams.volumeTrendMinSurge || 1.2
+
+  if (index < lookback - 1) return null
+
+  const slice = data.slice(index - lookback + 1, index + 1)
+  const volumes = slice.map((d) => d.volume)
+
+  const lastVolume = volumes[volumes.length - 1]
+  const avgVolume = volumes.slice(0, -1).reduce((sum, v) => sum + v, 0) / (volumes.length - 1)
+
+  // Remove one high-volume spike from trend scoring
+  const volumesForTrend = [...volumes]
+  const maxIndex = volumesForTrend.indexOf(Math.max(...volumesForTrend))
+  volumesForTrend.splice(maxIndex, 1)
+
+  // Pairwise up comparison
+  let upCount = 0
+  let total = 0
+  for (let i = 0; i < volumesForTrend.length - 1; i++) {
+    for (let j = i + 1; j < volumesForTrend.length; j++) {
+      total++
+      if (volumesForTrend[j] > volumesForTrend[i]) upCount++
+    }
+  }
+
+  const trendScore = total > 0 ? upCount / total : 0
+  const surgeRatio = avgVolume > 0 ? lastVolume / avgVolume : 0
+
+  // Only return trendScore if both conditions are met
+  if (trendScore >= minUpTrendScore && surgeRatio >= minSurgeMultiplier) {
+    return trendScore
+  }
+
+  return 0
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -88,7 +88,11 @@ export interface ExtTick extends Tick {
   movingAvg: number | undefined
   shortEmaAvg: number | undefined
   longEmaAvg: number | undefined
-  isMACrossingEMA: boolean | undefined
+  emaCrossing: {
+    crossing: boolean | undefined
+    direction: 'bullish' | 'bearish' | undefined
+  }
+  bollingerBreakout: boolean
   isBodyCrossing: boolean | undefined
   isWickCrossing: boolean | undefined
   crossesBodyAtPercent?: number | null

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -95,11 +95,14 @@ export interface ExtTick extends Tick {
   bollingerBreakout: boolean
   isBodyCrossing: boolean | undefined
   isWickCrossing: boolean | undefined
+  bearishEngulfingScore: number | null
+  isBullishExhaustion: boolean | null
   crossesBodyAtPercent?: number | null
   isCandleFull80: boolean
   candleBodyFullness: number
   candleBodyDistPercentile: number | undefined
   candleVolumeDistPercentile: number | undefined
+  volumeTrendIncreasing: number | null
   value: [string | undefined, null]
   percSlopeByPeriod: number | null
   priceSlopeByPeriod: number | null


### PR DESCRIPTION
Closes private issue #42

Adds final metrics for analysis.

VolumeTrend metric has several attempts - none of which fully solve the problem. This seems like it's going to be a long-term problem to keep working on. Merging all examples and moving forward.

Adds:
- EMACrossover
- BollingerBreakout
- RSI
- MACD
- Experimental VolumeTrend metrics